### PR TITLE
fromViewModel() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,8 @@ All notable changes to `view-export` will be documented in this file
 - make PdfExportService that provides static methods for initializing a PdfExporter from views or html
 - refactor Pdf construction, rendering & storage functionality to PdfExporter class for easier customization
 - add config file for changing default Dompdf Options
+
+
+## 0.7.3 - 2021-02-19
+- add fromViewModel method to PdfExportService for initializing from a ViewModel
+- add composer requiring of sfneal/view-models & tests for constructing from ViewModels

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "sfneal/dompdf": ">=0.9.5",
         "sfneal/laravel-helpers": ">=1.0.3",
         "sfneal/queueables": ">=1.0",
-        "sfneal/string-helpers": ">=1.1"
+        "sfneal/string-helpers": ">=1.1",
+        "sfneal/view-models": ">=1.1"
     },
     "require-dev": {
         "orchestra/testbench": ">=3.8.0",

--- a/src/Pdf/PdfExportService.php
+++ b/src/Pdf/PdfExportService.php
@@ -6,6 +6,7 @@ use Dompdf\Exception;
 use Illuminate\Contracts\View\View;
 use Sfneal\Actions\AbstractService;
 use Sfneal\ViewExport\Pdf\Utils\PdfExporter;
+use Sfneal\ViewModels\AbstractViewModel;
 
 class PdfExportService extends AbstractService
 {
@@ -34,6 +35,18 @@ class PdfExportService extends AbstractService
     public static function fromViewData(string $viewName, array $viewData = []): PdfExporter
     {
         return new PdfExporter(view($viewName, $viewData));
+    }
+
+    /**
+     * Provide a view to build the PDF from.
+     *
+     * @param AbstractViewModel $viewModel
+     * @return PdfExporter
+     * @throws Exception
+     */
+    public static function fromViewModel(AbstractViewModel $viewModel): PdfExporter
+    {
+        return new PdfExporter($viewModel->renderNoCache());
     }
 
     /**

--- a/tests/PdfExportFromViewModelTest.php
+++ b/tests/PdfExportFromViewModelTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sfneal\ViewExport\Tests;
+
+use Dompdf\Exception;
+use Sfneal\ViewExport\Pdf\PdfExportService;
+use Sfneal\ViewExport\Tests\Traits\PdfExportValidations;
+use Sfneal\ViewExport\Tests\ViewModels\TestViewModel;
+
+class PdfExportFromViewModelTest extends TestCase
+{
+    use PdfExportValidations;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     * @throws Exception
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->exporter = PdfExportService::fromViewModel(new TestViewModel());
+    }
+}

--- a/tests/ViewModels/TestViewModel.php
+++ b/tests/ViewModels/TestViewModel.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Sfneal\ViewExport\Tests\ViewModels;
+
+
+use Sfneal\ViewModels\AbstractViewModel;
+
+class TestViewModel extends AbstractViewModel
+{
+    public $view = 'test';
+}

--- a/tests/ViewModels/TestViewModel.php
+++ b/tests/ViewModels/TestViewModel.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\ViewExport\Tests\ViewModels;
-
 
 use Sfneal\ViewModels\AbstractViewModel;
 


### PR DESCRIPTION
- add fromViewModel method to PdfExportService for initializing from a ViewModel
- add composer requiring of sfneal/view-models & tests for constructing from ViewModels