### PR TITLE
view() & download() PdfExporter methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,3 +90,7 @@ All notable changes to `view-export` will be documented in this file
 ## 0.7.3 - 2021-02-19
 - add fromViewModel method to PdfExportService for initializing from a ViewModel
 - add composer requiring of sfneal/view-models & tests for constructing from ViewModels
+
+
+## 0.7.4 - 2021-02-19
+- add view() & download() methods to PdfExporter for viewing in browser & downloading PDFs

--- a/src/Pdf/Utils/PdfExporter.php
+++ b/src/Pdf/Utils/PdfExporter.php
@@ -78,7 +78,7 @@ class PdfExporter
      */
     public function view(string $filename = 'output.pdf')
     {
-        $this->pdf->stream($filename, ["Attachment" => false]);
+        $this->pdf->stream($filename, ['Attachment' => false]);
     }
 
     /**
@@ -88,7 +88,7 @@ class PdfExporter
      */
     public function download(string $filename = 'output.pdf')
     {
-        $this->pdf->stream($filename, ["Attachment" => true]);
+        $this->pdf->stream($filename, ['Attachment' => true]);
     }
 
     /**

--- a/src/Pdf/Utils/PdfExporter.php
+++ b/src/Pdf/Utils/PdfExporter.php
@@ -72,6 +72,26 @@ class PdfExporter
     }
 
     /**
+     * View the PDF in the clients browser.
+     *
+     * @param string $filename
+     */
+    public function view(string $filename = 'output.pdf')
+    {
+        $this->pdf->stream($filename, ["Attachment" => false]);
+    }
+
+    /**
+     * Download the PDF using the clients browser.
+     *
+     * @param string $filename
+     */
+    public function download(string $filename = 'output.pdf')
+    {
+        $this->pdf->stream($filename, ["Attachment" => true]);
+    }
+
+    /**
      * Retrieve the PDF's output.
      *
      * @return string


### PR DESCRIPTION
- add view() & download() methods to PdfExporter for viewing in browser & downloading PDFs