### PR TITLE
PdfExporter delayed rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,4 +98,10 @@ All notable changes to `view-export` will be documented in this file
 
 ## 0.7.5 - 2021-02-19
 - make DefaultOptions class for retrieving a Dompdf\Options instance with the defaults set
-- add ability to pass Options instances to PdfExportService methods.
+- add ability to pass Options instances to PdfExportService methods
+
+
+## 0.8.0 - 2021-02-22
+- refactor PdfExporter to not load content or render the pdf from the __construct method requiring a call to `render()`
+- refactor PdfExporter's $options property to be public to allow easier manipulation
+- add setLandscape() & setPortrait() methods to DefaultOptions for quickly changing paper orientation

--- a/src/Pdf/PdfExportAction.php
+++ b/src/Pdf/PdfExportAction.php
@@ -45,7 +45,7 @@ class PdfExportAction extends AbstractAction
     public function execute(): string
     {
         // Create & Render the PDF
-        $exporter = PdfExportService::fromViewData($this->view, $this->view_data);
+        $exporter = PdfExportService::fromViewData($this->view, $this->view_data)->render();
 
         // Upload the PDF to AWS S3
         $exporter->upload($this->path);

--- a/src/Pdf/PdfExportService.php
+++ b/src/Pdf/PdfExportService.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\ViewExport\Pdf;
 
-use Dompdf\Exception;
 use Dompdf\Options;
 use Illuminate\Contracts\View\View;
 use Sfneal\Actions\AbstractService;
@@ -19,7 +18,6 @@ class PdfExportService extends AbstractService
      * @param View $view
      * @param Options|null $options
      * @return PdfExporter
-     * @throws Exception
      */
     public static function fromView(View $view, Options $options = null): PdfExporter
     {
@@ -33,7 +31,6 @@ class PdfExportService extends AbstractService
      * @param array $viewData
      * @param Options|null $options
      * @return PdfExporter
-     * @throws Exception
      */
     public static function fromViewData(string $viewName, array $viewData = [], Options $options = null): PdfExporter
     {
@@ -46,7 +43,6 @@ class PdfExportService extends AbstractService
      * @param AbstractViewModel $viewModel
      * @param Options|null $options
      * @return PdfExporter
-     * @throws Exception
      */
     public static function fromViewModel(AbstractViewModel $viewModel, Options $options = null): PdfExporter
     {
@@ -59,7 +55,6 @@ class PdfExportService extends AbstractService
      * @param string $html
      * @param Options|null $options
      * @return PdfExporter
-     * @throws Exception
      */
     public static function fromHtml(string $html, Options $options = null): PdfExporter
     {
@@ -72,7 +67,6 @@ class PdfExportService extends AbstractService
      * @param string $path
      * @param Options|null $options
      * @return PdfExporter
-     * @throws Exception
      */
     public static function fromHtmlPath(string $path, Options $options = null): PdfExporter
     {

--- a/src/Pdf/Utils/DefaultOptions.php
+++ b/src/Pdf/Utils/DefaultOptions.php
@@ -37,24 +37,26 @@ class DefaultOptions extends Options
     }
 
     /**
-     * Set the paper orientation to 'landscape'
+     * Set the paper orientation to 'landscape'.
      *
      * @return $this
      */
     public function setLandscape(): self
     {
         $this->setDefaultPaperOrientation('landscape');
+
         return $this;
     }
 
     /**
-     * Set the paper orientation to 'portrait'
+     * Set the paper orientation to 'portrait'.
      *
      * @return $this
      */
     public function setPortrait(): self
     {
         $this->setDefaultPaperOrientation('portrait');
+
         return $this;
     }
 }

--- a/src/Pdf/Utils/DefaultOptions.php
+++ b/src/Pdf/Utils/DefaultOptions.php
@@ -37,4 +37,26 @@ class DefaultOptions extends Options
 
         return $this;
     }
+
+    /**
+     * Set the paper orientation to 'landscape'
+     *
+     * @return $this
+     */
+    public function setLandscape(): self
+    {
+        $this->setDefaultPaperOrientation('landscape');
+        return $this;
+    }
+
+    /**
+     * Set the paper orientation to 'portrait'
+     *
+     * @return $this
+     */
+    public function setPortrait(): self
+    {
+        $this->setDefaultPaperOrientation('portrait');
+        return $this;
+    }
 }

--- a/src/Pdf/Utils/PdfExporter.php
+++ b/src/Pdf/Utils/PdfExporter.php
@@ -14,7 +14,7 @@ class PdfExporter
     /**
      * @var Options
      */
-    private $options;
+    public $options;
 
     /**
      * @var Dompdf

--- a/src/Pdf/Utils/PdfExporter.php
+++ b/src/Pdf/Utils/PdfExporter.php
@@ -37,24 +37,60 @@ class PdfExporter
     private $output;
 
     /**
+     * @var View|string
+     */
+    private $content;
+
+    /**
      * PdfExporter constructor.
+     *
+     * - $content can be a View or HTML file contents
+     *
      * @param View|string $content
      * @param Options|null $options
-     * @throws Exception
      */
     public function __construct($content, Options $options = null)
     {
         // Declare PDF options (use DefaultOptions) if none provided
         $this->options = $options ?? new DefaultOptions();
 
+        // Content of the PDF
+        $this->content = $content;
+    }
+
+    /**
+     * Load PDF content to the Dompdf instance and render the output.
+     *
+     *  - storing output in a property avoids potentially calling expensive 'output()' method multiple times
+     *
+     * @return $this
+     * @throws Exception
+     */
+    public function render(): self
+    {
         // Instantiate dompdf
         $this->pdf = new Dompdf($this->options);
 
-        // Load content
-        $this->loadContent($content);
+        // Create local HTML file path
+        $localHTML = StringHelpers::joinPaths($this->options->getRootDir(), uniqid().'.html');
+
+        // Store View (or HTML) as HTML file within Dompdf root
+        touch($localHTML);
+        file_put_contents($localHTML, $this->content);
+
+        // Load HTML
+        $this->pdf->loadHtmlFile($localHTML);
+
+        // Remove temp HTML file
+        unlink($localHTML);
 
         // Render the PDF
-        $this->render();
+        $this->pdf->render();
+
+        // Store output to a property to avoid retrieving twice
+        $this->output = $this->pdf->output();
+
+        return $this;
     }
 
     /**
@@ -119,45 +155,5 @@ class PdfExporter
     public function getUrl(): ?string
     {
         return $this->url;
-    }
-
-    /**
-     * Load PDF content to the Dompdf instance.
-     *
-     *  - $content can be a View or HTML file contents
-     *
-     * @param View|string $content
-     * @return $this
-     * @throws Exception
-     */
-    private function loadContent($content): self
-    {
-        // Create local HTML file path
-        $localHTML = StringHelpers::joinPaths($this->options->getRootDir(), uniqid().'.html');
-
-        // Store View (or HTML) as HTML file within Dompdf root
-        touch($localHTML);
-        file_put_contents($localHTML, $content);
-
-        // Load HTML
-        $this->pdf->loadHtmlFile($localHTML);
-
-        // Remove temp HTML file
-        unlink($localHTML);
-
-        return $this;
-    }
-
-    /**
-     * Render a Dompdf & store it's output in a property.
-     *
-     *  - storing output in a property avoids potentially calling expensive 'output()' method multiple times
-     *
-     * @return void
-     */
-    private function render(): void
-    {
-        $this->pdf->render();
-        $this->output = $this->pdf->output();
     }
 }

--- a/tests/PdfExportFromHtmlPathTest.php
+++ b/tests/PdfExportFromHtmlPathTest.php
@@ -20,6 +20,8 @@ class PdfExportFromHtmlPathTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromHtmlPath(base_path('tests/resources/html/test.html'));
+        $this->exporter = PdfExportService::fromHtmlPath(
+            base_path('tests/resources/html/test.html')
+        )->render();
     }
 }

--- a/tests/PdfExportFromHtmlPathTest.php
+++ b/tests/PdfExportFromHtmlPathTest.php
@@ -20,8 +20,6 @@ class PdfExportFromHtmlPathTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromHtmlPath(
-            base_path('tests/resources/html/test.html')
-        )->render();
+        $this->exporter = PdfExportService::fromHtmlPath(base_path('tests/resources/html/test.html'));
     }
 }

--- a/tests/PdfExportFromHtmlPathTest.php
+++ b/tests/PdfExportFromHtmlPathTest.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\ViewExport\Tests;
 
-use Dompdf\Exception;
 use Sfneal\ViewExport\Pdf\PdfExportService;
 use Sfneal\ViewExport\Tests\Traits\PdfExportValidations;
 
@@ -14,7 +13,6 @@ class PdfExportFromHtmlPathTest extends TestCase
      * Setup the test environment.
      *
      * @return void
-     * @throws Exception
      */
     protected function setUp(): void
     {

--- a/tests/PdfExportFromHtmlTest.php
+++ b/tests/PdfExportFromHtmlTest.php
@@ -20,6 +20,8 @@ class PdfExportFromHtmlTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromHtml(file_get_contents(base_path('tests/resources/html/test.html')));
+        $this->exporter = PdfExportService::fromHtml(
+            file_get_contents(base_path('tests/resources/html/test.html'))
+        )->render();
     }
 }

--- a/tests/PdfExportFromHtmlTest.php
+++ b/tests/PdfExportFromHtmlTest.php
@@ -20,8 +20,6 @@ class PdfExportFromHtmlTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromHtml(
-            file_get_contents(base_path('tests/resources/html/test.html'))
-        )->render();
+        $this->exporter = PdfExportService::fromHtml(file_get_contents(base_path('tests/resources/html/test.html')));
     }
 }

--- a/tests/PdfExportFromHtmlTest.php
+++ b/tests/PdfExportFromHtmlTest.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\ViewExport\Tests;
 
-use Dompdf\Exception;
 use Sfneal\ViewExport\Pdf\PdfExportService;
 use Sfneal\ViewExport\Tests\Traits\PdfExportValidations;
 
@@ -14,7 +13,6 @@ class PdfExportFromHtmlTest extends TestCase
      * Setup the test environment.
      *
      * @return void
-     * @throws Exception
      */
     protected function setUp(): void
     {

--- a/tests/PdfExportFromViewDataTest.php
+++ b/tests/PdfExportFromViewDataTest.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\ViewExport\Tests;
 
-use Dompdf\Exception;
 use Sfneal\ViewExport\Pdf\PdfExportService;
 use Sfneal\ViewExport\Tests\Traits\PdfExportValidations;
 
@@ -14,7 +13,6 @@ class PdfExportFromViewDataTest extends TestCase
      * Setup the test environment.
      *
      * @return void
-     * @throws Exception
      */
     protected function setUp(): void
     {

--- a/tests/PdfExportFromViewDataTest.php
+++ b/tests/PdfExportFromViewDataTest.php
@@ -20,11 +20,6 @@ class PdfExportFromViewDataTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromViewData(
-            'test',
-            [
-                'string' => "Here's a string!"
-            ]
-        )->render();
+        $this->exporter = PdfExportService::fromViewData('test', ['string'=>"Here's a string!"]);
     }
 }

--- a/tests/PdfExportFromViewDataTest.php
+++ b/tests/PdfExportFromViewDataTest.php
@@ -20,6 +20,11 @@ class PdfExportFromViewDataTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromViewData('test', ['string'=>"Here's a string!"]);
+        $this->exporter = PdfExportService::fromViewData(
+            'test',
+            [
+                'string' => "Here's a string!"
+            ]
+        )->render();
     }
 }

--- a/tests/PdfExportFromViewModelTest.php
+++ b/tests/PdfExportFromViewModelTest.php
@@ -21,6 +21,8 @@ class PdfExportFromViewModelTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromViewModel(new TestViewModel());
+        $this->exporter = PdfExportService::fromViewModel(
+            new TestViewModel()
+        )->render();
     }
 }

--- a/tests/PdfExportFromViewModelTest.php
+++ b/tests/PdfExportFromViewModelTest.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\ViewExport\Tests;
 
-use Dompdf\Exception;
 use Sfneal\ViewExport\Pdf\PdfExportService;
 use Sfneal\ViewExport\Tests\Traits\PdfExportValidations;
 use Sfneal\ViewExport\Tests\ViewModels\TestViewModel;
@@ -15,7 +14,6 @@ class PdfExportFromViewModelTest extends TestCase
      * Setup the test environment.
      *
      * @return void
-     * @throws Exception
      */
     protected function setUp(): void
     {

--- a/tests/PdfExportFromViewModelTest.php
+++ b/tests/PdfExportFromViewModelTest.php
@@ -21,8 +21,6 @@ class PdfExportFromViewModelTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromViewModel(
-            new TestViewModel()
-        )->render();
+        $this->exporter = PdfExportService::fromViewModel(new TestViewModel());
     }
 }

--- a/tests/PdfExportFromViewTest.php
+++ b/tests/PdfExportFromViewTest.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\ViewExport\Tests;
 
-use Dompdf\Exception;
 use Sfneal\ViewExport\Pdf\PdfExportService;
 use Sfneal\ViewExport\Tests\Traits\PdfExportValidations;
 
@@ -14,7 +13,6 @@ class PdfExportFromViewTest extends TestCase
      * Setup the test environment.
      *
      * @return void
-     * @throws Exception
      */
     protected function setUp(): void
     {

--- a/tests/PdfExportFromViewTest.php
+++ b/tests/PdfExportFromViewTest.php
@@ -20,8 +20,6 @@ class PdfExportFromViewTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromView(
-            view('test')
-        )->render();
+        $this->exporter = PdfExportService::fromView(view('test'));
     }
 }

--- a/tests/PdfExportFromViewTest.php
+++ b/tests/PdfExportFromViewTest.php
@@ -20,6 +20,8 @@ class PdfExportFromViewTest extends TestCase
     {
         parent::setUp();
 
-        $this->exporter = PdfExportService::fromView(view('test'));
+        $this->exporter = PdfExportService::fromView(
+            view('test')
+        )->render();
     }
 }

--- a/tests/Traits/PdfExportValidations.php
+++ b/tests/Traits/PdfExportValidations.php
@@ -14,7 +14,7 @@ trait PdfExportValidations
     private $exporter;
 
     /**
-     * Execute PDfExport assertions
+     * Execute PDfExport assertions.
      */
     private function executeAssertions(): void
     {

--- a/tests/Traits/PdfExportValidations.php
+++ b/tests/Traits/PdfExportValidations.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\ViewExport\Tests\Traits;
 
+use Dompdf\Exception;
 use Sfneal\Helpers\Laravel\LaravelHelpers;
 use Sfneal\ViewExport\Pdf\Utils\PdfExporter;
 
@@ -18,9 +19,16 @@ trait PdfExportValidations
         $this->assertInstanceOf(PdfExporter::class, $this->exporter);
     }
 
-    /** @test */
-    public function validate_output_is_binary()
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function validate_output()
     {
+        // Render the PDF
+        $this->exporter->render();
+
+        // Execute assertions
         $this->assertNull($this->exporter->getPath());
         $this->assertNull($this->exporter->getUrl());
         $this->assertIsString($this->exporter->getOutput());

--- a/tests/Traits/PdfExportValidations.php
+++ b/tests/Traits/PdfExportValidations.php
@@ -49,6 +49,7 @@ trait PdfExportValidations
      */
     public function validate_landscape_output()
     {
+        // todo: add checks to confirm orientation
         // Change orientation to landscape
         $this->exporter->options->setLandscape();
 
@@ -65,6 +66,7 @@ trait PdfExportValidations
      */
     public function validate_portrait_output()
     {
+        // todo: add checks to confirm orientation
         // Change orientation to landscape
         $this->exporter->options->setPortrait();
 

--- a/tests/Traits/PdfExportValidations.php
+++ b/tests/Traits/PdfExportValidations.php
@@ -13,6 +13,17 @@ trait PdfExportValidations
      */
     private $exporter;
 
+    /**
+     * Execute PDfExport assertions
+     */
+    private function executeAssertions(): void
+    {
+        $this->assertNull($this->exporter->getPath());
+        $this->assertNull($this->exporter->getUrl());
+        $this->assertIsString($this->exporter->getOutput());
+        $this->assertTrue(LaravelHelpers::isBinary($this->exporter->getOutput()));
+    }
+
     /** @test */
     public function initialize_exporter()
     {
@@ -23,15 +34,44 @@ trait PdfExportValidations
      * @test
      * @throws Exception
      */
-    public function validate_output()
+    public function validate_standard_output()
     {
         // Render the PDF
         $this->exporter->render();
 
         // Execute assertions
-        $this->assertNull($this->exporter->getPath());
-        $this->assertNull($this->exporter->getUrl());
-        $this->assertIsString($this->exporter->getOutput());
-        $this->assertTrue(LaravelHelpers::isBinary($this->exporter->getOutput()));
+        $this->executeAssertions();
+    }
+
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function validate_landscape_output()
+    {
+        // Change orientation to landscape
+        $this->exporter->options->setLandscape();
+
+        // Render the PDF
+        $this->exporter->render();
+
+        // Execute assertions
+        $this->executeAssertions();
+    }
+
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function validate_portrait_output()
+    {
+        // Change orientation to landscape
+        $this->exporter->options->setPortrait();
+
+        // Render the PDF
+        $this->exporter->render();
+
+        // Execute assertions
+        $this->executeAssertions();
     }
 }


### PR DESCRIPTION
- refactor PdfExporter to not load content or render the pdf from the __construct method requiring a call to `render()`
- refactor PdfExporter's $options property to be public to allow easier manipulation
- add setLandscape() & setPortrait() methods to DefaultOptions for quickly changing paper orientation