### PR TITLE
Fixed issues pushing Renderer instances to Job Queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,9 @@ All notable changes to `view-export` will be documented in this file
 - add ability to provide n file upload path to the __construct method of Renderer
 - cut $options params from PdfExportService & PdfRenderer
 - cut $metadata param from Renderer::__construct method
+
+
+## 0.9.1 - 2021-02-24
+- refactor PdfRenderer::render() method to handle()
+- fix issue with View's being non-serializable and causing errors when pushing to queues
+- refactor Renderer to use a non-static `dispatch()` method for dispatching a Renderer instance to the Job queue

--- a/src/Pdf/PdfExportService.php
+++ b/src/Pdf/PdfExportService.php
@@ -19,7 +19,7 @@ class PdfExportService
      */
     public static function fromView(View $view, string $uploadPath = null): Renderer
     {
-        return new Renderer($view, $uploadPath);
+        return new Renderer($view->render(), $uploadPath);
     }
 
     /**
@@ -34,7 +34,7 @@ class PdfExportService
      */
     public static function fromViewData(string $viewName, array $viewData = [], string $uploadPath = null): Renderer
     {
-        return new Renderer(view($viewName, $viewData), $uploadPath);
+        return new Renderer(view($viewName, $viewData)->render(), $uploadPath);
     }
 
     /**

--- a/src/Pdf/PdfExportService.php
+++ b/src/Pdf/PdfExportService.php
@@ -25,6 +25,8 @@ class PdfExportService
     /**
      * Create a view to build the PDF from.
      *
+     * // todo: remove this method?
+     *
      * @param string $viewName
      * @param array $viewData
      * @param string|null $uploadPath

--- a/src/Pdf/PdfExportService.php
+++ b/src/Pdf/PdfExportService.php
@@ -3,11 +3,10 @@
 namespace Sfneal\ViewExport\Pdf;
 
 use Illuminate\Contracts\View\View;
-use Sfneal\Actions\AbstractService;
 use Sfneal\ViewExport\Pdf\Utils\Renderer;
 use Sfneal\ViewModels\AbstractViewModel;
 
-class PdfExportService extends AbstractService
+class PdfExportService
 {
     // todo: add ability to pass urls to export
 

--- a/src/Pdf/Utils/Renderer.php
+++ b/src/Pdf/Utils/Renderer.php
@@ -64,7 +64,7 @@ class Renderer
     }
 
     /**
-     * Dispatch this renderer instance to the Job queue without having to construct it statically
+     * Dispatch this renderer instance to the Job queue without having to construct it statically.
      *
      * @return mixed
      */

--- a/src/Pdf/Utils/Renderer.php
+++ b/src/Pdf/Utils/Renderer.php
@@ -5,14 +5,18 @@ namespace Sfneal\ViewExport\Pdf\Utils;
 use Dompdf\Dompdf;
 use Dompdf\Exception;
 use Dompdf\Options;
-use Illuminate\Contracts\View\View;
+use Illuminate\Bus\Queueable as QueueableTrait;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Bus;
 use Sfneal\Helpers\Strings\StringHelpers;
-use Sfneal\Queueables\AbstractJob;
 
-class Renderer extends AbstractJob
+class Renderer
 {
+    use InteractsWithQueue, QueueableTrait, SerializesModels;
+
     /**
-     * @var View|string PDF content (either a View or HTML string)
+     * @var string PDF content (either a rendered View or HTML string)
      */
     private $content;
 
@@ -41,10 +45,10 @@ class Renderer extends AbstractJob
      *
      * - $content can be a View or HTML file contents
      *
-     * @param View|string $content
+     * @param string $content
      * @param string|null $uploadPath
      */
-    public function __construct($content, string $uploadPath = null)
+    public function __construct(string $content, string $uploadPath = null)
     {
         // Content of the PDF
         $this->content = $content;
@@ -57,6 +61,16 @@ class Renderer extends AbstractJob
 
         // Instantiate Metadata
         $this->metadata = new Metadata();
+    }
+
+    /**
+     * Dispatch this renderer instance to the Job queue without having to construct it statically
+     *
+     * @return mixed
+     */
+    public function dispatch()
+    {
+        return Bus::dispatch($this);
     }
 
     /**

--- a/tests/Traits/PdfExportValidations.php
+++ b/tests/Traits/PdfExportValidations.php
@@ -3,6 +3,7 @@
 namespace Sfneal\ViewExport\Tests\Traits;
 
 use Dompdf\Exception;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
 use Sfneal\Helpers\Laravel\LaravelHelpers;
 use Sfneal\ViewExport\Pdf\Utils\Exporter;
@@ -97,7 +98,7 @@ trait PdfExportValidations
     }
 
     /** @test */
-    public function validate_queueable_renderer()
+    public function validate_queueable_renderer_with_queue()
     {
         // Enable queue faking
         Queue::fake();
@@ -110,5 +111,21 @@ trait PdfExportValidations
 
         // Assert a job was pushed twice...
         Queue::assertPushed(Renderer::class, 1);
+    }
+
+    /** @test */
+    public function validate_queueable_non_static()
+    {
+        // Enable queue faking
+        Bus::fake();
+
+        // Assert that no jobs were pushed...
+        Bus::assertNotDispatched(Renderer::class);
+
+        // Dispatch the first job...
+        $this->renderer->dispatch();
+
+        // Assert a job was pushed twice...
+        Bus::assertDispatched(Renderer::class);
     }
 }


### PR DESCRIPTION
- refactor PdfRenderer::render() method to handle()
- fix issue with View's being non-serializable and causing errors when pushing to queues
- refactor Renderer to use a non-static `dispatch()` method for dispatching a Renderer instance to the Job queue