### PR TITLE
Queueing Renderer instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,3 +130,7 @@ All notable changes to `view-export` will be documented in this file
 - refactor PdfRenderer::render() method to handle()
 - fix issue with View's being non-serializable and causing errors when pushing to queues
 - refactor Renderer to use a non-static `dispatch()` method for dispatching a Renderer instance to the Job queue
+
+
+## 0.9.2 - 2021-02-24
+- fix issues queueing non-static Renderer instances by refactoring `dispatch()` method to `handleJob()` to prevent conflicts

--- a/src/Pdf/Utils/Renderer.php
+++ b/src/Pdf/Utils/Renderer.php
@@ -5,16 +5,12 @@ namespace Sfneal\ViewExport\Pdf\Utils;
 use Dompdf\Dompdf;
 use Dompdf\Exception;
 use Dompdf\Options;
-use Illuminate\Bus\Queueable as QueueableTrait;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Bus;
 use Sfneal\Helpers\Strings\StringHelpers;
+use Sfneal\Queueables\AbstractJob;
 
-class Renderer
+class Renderer extends AbstractJob
 {
-    use InteractsWithQueue, QueueableTrait, SerializesModels;
-
     /**
      * @var string PDF content (either a rendered View or HTML string)
      */
@@ -68,7 +64,7 @@ class Renderer
      *
      * @return mixed
      */
-    public function dispatch()
+    public function handleJob()
     {
         return Bus::dispatch($this);
     }

--- a/tests/Traits/PdfExportValidations.php
+++ b/tests/Traits/PdfExportValidations.php
@@ -123,7 +123,7 @@ trait PdfExportValidations
         Bus::assertNotDispatched(Renderer::class);
 
         // Dispatch the first job...
-        $this->renderer->dispatch();
+        $this->renderer->handleJob();
 
         // Assert a job was pushed twice...
         Bus::assertDispatched(Renderer::class);


### PR DESCRIPTION
- fix issues queueing non-static Renderer instances by refactoring `dispatch()` method to `handleJob()` to prevent conflicts