### PR TITLE
Refactor Exporter & PdfExportService methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,3 +134,9 @@ All notable changes to `view-export` will be documented in this file
 
 ## 0.9.2 - 2021-02-24
 - fix issues queueing non-static Renderer instances by refactoring `dispatch()` method to `handleJob()` to prevent conflicts
+
+
+## 0.10.0 - 2021-02-24
+- cut 'get' prefix from Exporter's `output()`, `path()` & `url()` methods
+- cut `fromViewData()` method from PdfExportService as there's no advantage of using that instead of `fromView()`
+- fix use of PdfExportService in PdfExportAction to use `fromView()` method instead of `fromViewData()`

--- a/src/Pdf/PdfExportAction.php
+++ b/src/Pdf/PdfExportAction.php
@@ -51,6 +51,6 @@ class PdfExportAction extends AbstractAction
         $exporter->upload($this->path);
 
         // Return the path
-        return $exporter->getPath();
+        return $exporter->path();
     }
 }

--- a/src/Pdf/PdfExportAction.php
+++ b/src/Pdf/PdfExportAction.php
@@ -45,7 +45,7 @@ class PdfExportAction extends AbstractAction
     public function execute(): string
     {
         // Create & Render the PDF
-        $exporter = PdfExportService::fromViewData($this->view, $this->view_data)->handle();
+        $exporter = PdfExportService::fromView(view($this->view, $this->view_data))->handle();
 
         // Upload the PDF to AWS S3
         $exporter->upload($this->path);

--- a/src/Pdf/PdfExportService.php
+++ b/src/Pdf/PdfExportService.php
@@ -23,21 +23,6 @@ class PdfExportService
     }
 
     /**
-     * Create a view to build the PDF from.
-     *
-     * // todo: remove this method?
-     *
-     * @param string $viewName
-     * @param array $viewData
-     * @param string|null $uploadPath
-     * @return Renderer
-     */
-    public static function fromViewData(string $viewName, array $viewData = [], string $uploadPath = null): Renderer
-    {
-        return new Renderer(view($viewName, $viewData)->render(), $uploadPath);
-    }
-
-    /**
      * Provide a view to build the PDF from.
      *
      * @param AbstractViewModel $viewModel

--- a/src/Pdf/Utils/Exporter.php
+++ b/src/Pdf/Utils/Exporter.php
@@ -51,7 +51,7 @@ class Exporter
     public function upload(string $path): self
     {
         $this->path = $path;
-        $this->url = (new S3($path))->upload_raw($this->getOutput());
+        $this->url = (new S3($path))->upload_raw($this->output());
 
         return $this;
     }
@@ -81,7 +81,7 @@ class Exporter
      *
      * @return string
      */
-    public function getOutput(): string
+    public function output(): string
     {
         return $this->output;
     }
@@ -91,7 +91,7 @@ class Exporter
      *
      * @return string|null
      */
-    public function getPath(): ?string
+    public function path(): ?string
     {
         return $this->path;
     }
@@ -101,7 +101,7 @@ class Exporter
      *
      * @return string|null
      */
-    public function getUrl(): ?string
+    public function url(): ?string
     {
         return $this->url;
     }

--- a/tests/PdfExportFromViewWithTest.php
+++ b/tests/PdfExportFromViewWithTest.php
@@ -5,7 +5,7 @@ namespace Sfneal\ViewExport\Tests;
 use Sfneal\ViewExport\Pdf\PdfExportService;
 use Sfneal\ViewExport\Tests\Traits\PdfExportValidations;
 
-class PdfExportFromViewDataTest extends TestCase
+class PdfExportFromViewWithTest extends TestCase
 {
     use PdfExportValidations;
 
@@ -18,6 +18,6 @@ class PdfExportFromViewDataTest extends TestCase
     {
         parent::setUp();
 
-        $this->renderer = PdfExportService::fromViewData('test', ['string'=>"Here's a string!"]);
+        $this->renderer = PdfExportService::fromView(view('test', ['string'=>"Here's a string!"]));
     }
 }

--- a/tests/Traits/PdfExportValidations.php
+++ b/tests/Traits/PdfExportValidations.php
@@ -22,10 +22,10 @@ trait PdfExportValidations
      */
     private function executeAssertions(Exporter $exporter): void
     {
-        $this->assertNull($exporter->getPath());
-        $this->assertNull($exporter->getUrl());
-        $this->assertIsString($exporter->getOutput());
-        $this->assertTrue(LaravelHelpers::isBinary($exporter->getOutput()));
+        $this->assertNull($exporter->path());
+        $this->assertNull($exporter->url());
+        $this->assertIsString($exporter->output());
+        $this->assertTrue(LaravelHelpers::isBinary($exporter->output()));
     }
 
     /** @test */


### PR DESCRIPTION
- cut 'get' prefix from Exporter's `output()`, `path()` & `url()` methods
- cut `fromViewData()` method from PdfExportService as there's no advantage of using that instead of `fromView()`
- fix use of PdfExportService in PdfExportAction to use `fromView()` method instead of `fromViewData()`