### PR TITLE
PdfExportJob fixes

### DIFF
--- a/src/Pdf/PdfExportJob.php
+++ b/src/Pdf/PdfExportJob.php
@@ -21,7 +21,7 @@ class PdfExportJob extends AbstractJob
     /**
      * @var Renderer
      */
-    private $renderer;
+    protected $renderer;
 
     /**
      * PdfExportJob constructor.

--- a/src/Pdf/PdfExportJob.php
+++ b/src/Pdf/PdfExportJob.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\ViewExport\Pdf;
 
+use Dompdf\Exception;
 use Sfneal\Queueables\AbstractJob;
 use Sfneal\ViewExport\Pdf\Utils\Renderer;
 
@@ -36,9 +37,10 @@ class PdfExportJob extends AbstractJob
      * Render a PDF & upload it to AWS S3.
      *
      * @return string
+     * @throws Exception
      */
     public function handle(): string
     {
-        $this->renderer->handleJob();
+        $this->renderer->handle();
     }
 }

--- a/src/Pdf/PdfExportJob.php
+++ b/src/Pdf/PdfExportJob.php
@@ -41,6 +41,6 @@ class PdfExportJob extends AbstractJob
      */
     public function handle(): string
     {
-        $this->renderer->handle();
+        $this->renderer->handle()->path();
     }
 }

--- a/src/Pdf/PdfExportJob.php
+++ b/src/Pdf/PdfExportJob.php
@@ -41,6 +41,6 @@ class PdfExportJob extends AbstractJob
      */
     public function handle(): string
     {
-        $this->renderer->handle()->path();
+        return $this->renderer->handle()->path();
     }
 }


### PR DESCRIPTION
- fix issues with PdfExportJob failing due to `$renderer` property being 'private'
- fix PdfExportJob::handle() method to return the PDF's upload path