### PR TITLE
Support namespace refactor & Excel downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,5 +190,10 @@ All notable changes to `view-export` will be documented in this file
 - add test method for testing exporting Excel files from a Collection
 
 
-## 2.1.1 - 2021-03-23
+## 2.2.0 - 2021-03-23
 - refactor `ExcelRenderer@setExcelView()` to `ExcelRenderer@setExcelExport()`
+- refactor `Streamable` interface into two separate `Viewable` & `Downloadable` interfaces
+- refactor abstract classes from 'Support' namespace into 'Sfneal\ViewExport\Support\Adapters' namespace
+- refactor interfaces from 'Support' namespace into 'Sfneal\ViewExport\Support\Interfaces' namespace.
+- add `download()` method to `ExcelExporter`
+- add use of `Storage` facade for uploading files to S3 instead of the S3 helper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,3 +188,7 @@ All notable changes to `view-export` will be documented in this file
 - refactor `Sfneal\ViewExport\Excel\Utils\ExcelView` to `Sfneal\ViewExport\Excel\Exports\ExcelViewExport` for easier expansion
 - fix `ExcelRenderer::setExcelView()` method to use string type hinting for $viewClass param
 - add test method for testing exporting Excel files from a Collection
+
+
+## 2.1.1 - 2021-03-23
+- refactor `ExcelRenderer@setExcelView()` to `ExcelRenderer@setExcelExport()`

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "dompdf/dompdf": ">=1.0",
         "laravel/framework": ">=7",
         "maatwebsite/excel": ">=3.1",
-        "sfneal/aws-s3-helpers": ">=0.4.0",
         "sfneal/laravel-helpers": ">=1.0.3",
         "sfneal/queueables": ">=1.0",
         "sfneal/string-helpers": ">=1.1",

--- a/src/Excel/ExcelExportService.php
+++ b/src/Excel/ExcelExportService.php
@@ -4,7 +4,7 @@ namespace Sfneal\ViewExport\Excel;
 
 use Illuminate\Contracts\View\View;
 use Sfneal\ViewExport\Excel\Utils\ExcelRenderer;
-use Sfneal\ViewExport\Support\ExportService;
+use Sfneal\ViewExport\Support\Adapters\ExportService;
 use Sfneal\ViewModels\AbstractViewModel;
 
 class ExcelExportService extends ExportService

--- a/src/Excel/Exports/CollectionExcelExport.php
+++ b/src/Excel/Exports/CollectionExcelExport.php
@@ -4,7 +4,7 @@ namespace Sfneal\ViewExport\Excel\Exports;
 
 use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\FromCollection;
-use Sfneal\ViewExport\Support\ExcelExport;
+use Sfneal\ViewExport\Support\Adapters\ExcelExport;
 
 class CollectionExcelExport extends ExcelExport implements FromCollection
 {

--- a/src/Excel/Exports/ViewExcelExport.php
+++ b/src/Excel/Exports/ViewExcelExport.php
@@ -4,7 +4,7 @@ namespace Sfneal\ViewExport\Excel\Exports;
 
 use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Concerns\FromView;
-use Sfneal\ViewExport\Support\ExcelExport;
+use Sfneal\ViewExport\Support\Adapters\ExcelExport;
 
 class ViewExcelExport extends ExcelExport implements FromView
 {

--- a/src/Excel/Utils/ExcelExporter.php
+++ b/src/Excel/Utils/ExcelExporter.php
@@ -5,11 +5,11 @@ namespace Sfneal\ViewExport\Excel\Utils;
 use Maatwebsite\Excel\Facades\Excel;
 use Sfneal\ViewExport\Support\Adapters\ExcelExport;
 use Sfneal\ViewExport\Support\Adapters\Exporter;
+use Sfneal\ViewExport\Support\Interfaces\Downloadable;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
-class ExcelExporter extends Exporter
+class ExcelExporter extends Exporter implements Downloadable
 {
-    // todo: add ability to download
-
     /**
      * @var ExcelExport
      */
@@ -56,5 +56,16 @@ class ExcelExporter extends Exporter
         Excel::store($this->excel, $storagePath);
 
         return $this;
+    }
+
+    /**
+     * Download the exported view using the clients browser.
+     *
+     * @param string $filename
+     * @return BinaryFileResponse
+     */
+    public function download(string $filename): BinaryFileResponse
+    {
+        return Excel::download($this->excel, $filename);
     }
 }

--- a/src/Excel/Utils/ExcelExporter.php
+++ b/src/Excel/Utils/ExcelExporter.php
@@ -3,8 +3,8 @@
 namespace Sfneal\ViewExport\Excel\Utils;
 
 use Maatwebsite\Excel\Facades\Excel;
-use Sfneal\ViewExport\Support\ExcelExport;
-use Sfneal\ViewExport\Support\Exporter;
+use Sfneal\ViewExport\Support\Adapters\ExcelExport;
+use Sfneal\ViewExport\Support\Adapters\Exporter;
 
 class ExcelExporter extends Exporter
 {

--- a/src/Excel/Utils/ExcelRenderer.php
+++ b/src/Excel/Utils/ExcelRenderer.php
@@ -3,8 +3,8 @@
 namespace Sfneal\ViewExport\Excel\Utils;
 
 use Sfneal\ViewExport\Excel\Exports\ViewExcelExport;
-use Sfneal\ViewExport\Support\Exporter;
-use Sfneal\ViewExport\Support\Renderer;
+use Sfneal\ViewExport\Support\Adapters\Exporter;
+use Sfneal\ViewExport\Support\Adapters\Renderer;
 
 class ExcelRenderer extends Renderer
 {

--- a/src/Excel/Utils/ExcelRenderer.php
+++ b/src/Excel/Utils/ExcelRenderer.php
@@ -11,17 +11,17 @@ class ExcelRenderer extends Renderer
     /**
      * @var string
      */
-    private $excelViewClass = ViewExcelExport::class;
+    private $excelExportClass = ViewExcelExport::class;
 
     /**
-     * Set the ExcelView class to be used to render the Excel file.
+     * Set the `ExcelExport` class to be used to render the Excel file.
      *
-     * @param string $viewClass
+     * @param string $exportClass
      * @return $this
      */
-    public function setExcelView(string $viewClass): self
+    public function setExcelExport(string $exportClass): self
     {
-        $this->excelViewClass = $viewClass;
+        $this->excelExportClass = $exportClass;
 
         return $this;
     }
@@ -33,7 +33,7 @@ class ExcelRenderer extends Renderer
      */
     protected function render(): object
     {
-        return new $this->excelViewClass($this->content);
+        return new $this->excelExportClass($this->content);
     }
 
     /**

--- a/src/Pdf/PdfExportService.php
+++ b/src/Pdf/PdfExportService.php
@@ -4,8 +4,8 @@ namespace Sfneal\ViewExport\Pdf;
 
 use Illuminate\Contracts\View\View;
 use Sfneal\ViewExport\Pdf\Utils\PdfRenderer;
-use Sfneal\ViewExport\Support\ExportService;
-use Sfneal\ViewExport\Support\FromHtml;
+use Sfneal\ViewExport\Support\Adapters\ExportService;
+use Sfneal\ViewExport\Support\Interfaces\FromHtml;
 use Sfneal\ViewModels\AbstractViewModel;
 
 class PdfExportService extends ExportService implements FromHtml

--- a/src/Pdf/Utils/PdfExporter.php
+++ b/src/Pdf/Utils/PdfExporter.php
@@ -3,9 +3,9 @@
 namespace Sfneal\ViewExport\Pdf\Utils;
 
 use Dompdf\Dompdf;
-use Sfneal\ViewExport\Support\Downloadable;
-use Sfneal\ViewExport\Support\Exporter;
-use Sfneal\ViewExport\Support\Viewable;
+use Sfneal\ViewExport\Support\Adapters\Exporter;
+use Sfneal\ViewExport\Support\Interfaces\Downloadable;
+use Sfneal\ViewExport\Support\Interfaces\Viewable;
 
 class PdfExporter extends Exporter implements Viewable, Downloadable
 {

--- a/src/Pdf/Utils/PdfExporter.php
+++ b/src/Pdf/Utils/PdfExporter.php
@@ -3,10 +3,11 @@
 namespace Sfneal\ViewExport\Pdf\Utils;
 
 use Dompdf\Dompdf;
+use Sfneal\ViewExport\Support\Downloadable;
 use Sfneal\ViewExport\Support\Exporter;
-use Sfneal\ViewExport\Support\Streamable;
+use Sfneal\ViewExport\Support\Viewable;
 
-class PdfExporter extends Exporter implements Streamable
+class PdfExporter extends Exporter implements Viewable, Downloadable
 {
     /**
      * @var Dompdf

--- a/src/Pdf/Utils/PdfRenderer.php
+++ b/src/Pdf/Utils/PdfRenderer.php
@@ -6,8 +6,8 @@ use Dompdf\Dompdf;
 use Dompdf\Exception;
 use Dompdf\Options;
 use Sfneal\Helpers\Strings\StringHelpers;
-use Sfneal\ViewExport\Support\Exporter;
-use Sfneal\ViewExport\Support\Renderer;
+use Sfneal\ViewExport\Support\Adapters\Exporter;
+use Sfneal\ViewExport\Support\Adapters\Renderer;
 
 class PdfRenderer extends Renderer
 {

--- a/src/Support/Adapters/ExcelExport.php
+++ b/src/Support/Adapters/ExcelExport.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Sfneal\ViewExport\Support\Adapters;
+
+abstract class ExcelExport
+{
+}

--- a/src/Support/Adapters/ExportService.php
+++ b/src/Support/Adapters/ExportService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\ViewExport\Support;
+namespace Sfneal\ViewExport\Support\Adapters;
 
 use Illuminate\Contracts\View\View;
 use Sfneal\ViewModels\AbstractViewModel;

--- a/src/Support/Adapters/ExportService.php
+++ b/src/Support/Adapters/ExportService.php
@@ -8,7 +8,7 @@ use Sfneal\ViewModels\AbstractViewModel;
 abstract class ExportService
 {
     /**
-     * Provide a view to build the PDF from.
+     * Provide a view to build the export from.
      *
      * @param View $view
      * @param string|null $uploadPath
@@ -17,7 +17,7 @@ abstract class ExportService
     abstract public static function fromView(View $view, string $uploadPath = null): Renderer;
 
     /**
-     * Provide a view to build the PDF from.
+     * Provide a view to build the export from.
      *
      * @param AbstractViewModel $viewModel
      * @param string|null $uploadPath

--- a/src/Support/Adapters/Exporter.php
+++ b/src/Support/Adapters/Exporter.php
@@ -6,8 +6,6 @@ use Illuminate\Support\Facades\Storage;
 
 abstract class Exporter
 {
-    // todo: fix docstrings to not be pdf specific
-
     /**
      * @var string|null local file path
      */

--- a/src/Support/Adapters/Exporter.php
+++ b/src/Support/Adapters/Exporter.php
@@ -3,7 +3,6 @@
 namespace Sfneal\ViewExport\Support\Adapters;
 
 use Illuminate\Support\Facades\Storage;
-use Sfneal\Helpers\Aws\S3\S3;
 
 abstract class Exporter
 {
@@ -37,10 +36,9 @@ abstract class Exporter
      */
     public function upload(string $path): self
     {
+        Storage::disk('s3')->put($path, $this->output());
         $this->uploadPath = $path;
-
-        // todo: add use of Storage
-        $this->url = (new S3($path))->upload_raw($this->output());
+        $this->url = Storage::disk('s3')->url($path);
 
         return $this;
     }

--- a/src/Support/Adapters/Exporter.php
+++ b/src/Support/Adapters/Exporter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\ViewExport\Support;
+namespace Sfneal\ViewExport\Support\Adapters;
 
 use Illuminate\Support\Facades\Storage;
 use Sfneal\Helpers\Aws\S3\S3;

--- a/src/Support/Adapters/Exporter.php
+++ b/src/Support/Adapters/Exporter.php
@@ -29,7 +29,7 @@ abstract class Exporter
     protected $output;
 
     /**
-     * Upload a rendered PDF to an AWS S3 file store.
+     * Upload a rendered export to an AWS S3 file store.
      *
      * @param string $path
      * @return $this
@@ -44,7 +44,7 @@ abstract class Exporter
     }
 
     /**
-     * Store a rendered PDF on the local file system.
+     * Store a rendered export on the local file system.
      *
      * @param string $storagePath
      * @return $this
@@ -58,7 +58,7 @@ abstract class Exporter
     }
 
     /**
-     * Retrieve the PDF's output.
+     * Retrieve the export's output.
      *
      * @return string|null
      */
@@ -68,7 +68,7 @@ abstract class Exporter
     }
 
     /**
-     * Retrieve the PDF's AWS S3 path if available or the local file path.
+     * Retrieve the export's AWS S3 path if available or the local file path.
      *
      * @return string|null
      */
@@ -78,7 +78,7 @@ abstract class Exporter
     }
 
     /**
-     * Retrieve the PDF's AWS S3 path.
+     * Retrieve the export's AWS S3 path.
      *
      * @return string|null
      */
@@ -88,7 +88,7 @@ abstract class Exporter
     }
 
     /**
-     * Retrieve the PDF's local file path.
+     * Retrieve the export's local file path.
      *
      * @return string|null
      */
@@ -98,7 +98,7 @@ abstract class Exporter
     }
 
     /**
-     * Retrieve the PDF's AWS S3 url.
+     * Retrieve the export's AWS S3 url.
      *
      * @return string|null
      */

--- a/src/Support/Adapters/Renderer.php
+++ b/src/Support/Adapters/Renderer.php
@@ -13,7 +13,7 @@ abstract class Renderer extends AbstractJob
     protected $content;
 
     /**
-     * @var string|null AWS S3 path to upload PDF to after render (if provided)
+     * @var string|null AWS S3 path to upload a file to after render (if provided)
      */
     protected $uploadPath;
 

--- a/src/Support/Adapters/Renderer.php
+++ b/src/Support/Adapters/Renderer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\ViewExport\Support;
+namespace Sfneal\ViewExport\Support\Adapters;
 
 use Illuminate\Support\Facades\Bus;
 use Sfneal\Queueables\AbstractJob;

--- a/src/Support/Downloadable.php
+++ b/src/Support/Downloadable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sfneal\ViewExport\Support;
+
+interface Downloadable
+{
+    /**
+     * Download the exported view using the clients browser.
+     *
+     * @param string $filename
+     * @return void
+     */
+    public function download(string $filename): void;
+}

--- a/src/Support/ExcelExport.php
+++ b/src/Support/ExcelExport.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Sfneal\ViewExport\Support;
-
-abstract class ExcelExport
-{
-}

--- a/src/Support/Exporter.php
+++ b/src/Support/Exporter.php
@@ -7,7 +7,6 @@ use Sfneal\Helpers\Aws\S3\S3;
 
 abstract class Exporter
 {
-    // todo: add ability to store locally
     // todo: fix docstrings to not be pdf specific
 
     /**

--- a/src/Support/Interfaces/Downloadable.php
+++ b/src/Support/Interfaces/Downloadable.php
@@ -8,7 +8,7 @@ interface Downloadable
      * Download the exported view using the clients browser.
      *
      * @param string $filename
-     * @return void
+     * @return void|mixed
      */
-    public function download(string $filename): void;
+    public function download(string $filename);
 }

--- a/src/Support/Interfaces/Downloadable.php
+++ b/src/Support/Interfaces/Downloadable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\ViewExport\Support;
+namespace Sfneal\ViewExport\Support\Interfaces;
 
 interface Downloadable
 {

--- a/src/Support/Interfaces/FromHtml.php
+++ b/src/Support/Interfaces/FromHtml.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Sfneal\ViewExport\Support;
+namespace Sfneal\ViewExport\Support\Interfaces;
+
+use Sfneal\ViewExport\Support\Adapters\Renderer;
 
 interface FromHtml
 {

--- a/src/Support/Interfaces/Viewable.php
+++ b/src/Support/Interfaces/Viewable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sfneal\ViewExport\Support;
+namespace Sfneal\ViewExport\Support\Interfaces;
 
 interface Viewable
 {

--- a/src/Support/Viewable.php
+++ b/src/Support/Viewable.php
@@ -2,7 +2,7 @@
 
 namespace Sfneal\ViewExport\Support;
 
-interface Streamable
+interface Viewable
 {
     /**
      * View the exported view in the clients browser.
@@ -11,12 +11,4 @@ interface Streamable
      * @return void
      */
     public function view(string $filename): void;
-
-    /**
-     * Download the exported view using the clients browser.
-     *
-     * @param string $filename
-     * @return void
-     */
-    public function download(string $filename): void;
 }

--- a/tests/Excel/ExcelTestCase.php
+++ b/tests/Excel/ExcelTestCase.php
@@ -72,7 +72,7 @@ abstract class ExcelTestCase extends TestCase
     public function validate_output_with_custom_view_export()
     {
         // Add use of custom ExcelViewExport
-        $this->renderer->setExcelView(TestViewExcelExport::class);
+        $this->renderer->setExcelExport(TestViewExcelExport::class);
 
         // Render the PDF
         $exporter = $this->renderer->handle();
@@ -88,7 +88,7 @@ abstract class ExcelTestCase extends TestCase
     public function validate_output_with_custom_collection_export()
     {
         // Add use of custom ExcelViewExport
-        $this->renderer->setExcelView(TestCollectionExcelExport::class);
+        $this->renderer->setExcelExport(TestCollectionExcelExport::class);
 
         // Render the PDF
         $exporter = $this->renderer->handle()->store('excel/output-'.random_int(1000, 9999).'.xlsx');


### PR DESCRIPTION
- refactor `ExcelRenderer@setExcelView()` to `ExcelRenderer@setExcelExport()`
- refactor `Streamable` interface into two separate `Viewable` & `Downloadable` interfaces
- refactor abstract classes from 'Support' namespace into 'Sfneal\ViewExport\Support\Adapters' namespace
- refactor interfaces from 'Support' namespace into 'Sfneal\ViewExport\Support\Interfaces' namespace.
- add `download()` method to `ExcelExporter`
- add use of `Storage` facade for uploading files to S3 instead of the S3 helper