### PR TITLE
Uploading/storing renders from queued jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,11 +184,6 @@ All notable changes to `view-export` will be documented in this file
 - optimize composer requirements by removing unused dependencies
 
 
-## 2.1.0 - 2021-03-24
-- cut $uploadPath param from `ExportService` methods & `Renderer` constructor in favor of using `Renderer::upload()` method
-- add methods to `Renderer` that allow for setting upload or storage paths prior to executing rendering (useful when interacting with the queue)
-
-
 ## 2.1.0 - 2021-03-22
 - refactor `Sfneal\ViewExport\Excel\Utils\ExcelView` to `Sfneal\ViewExport\Excel\Exports\ExcelViewExport` for easier expansion
 - fix `ExcelRenderer::setExcelView()` method to use string type hinting for $viewClass param
@@ -202,3 +197,8 @@ All notable changes to `view-export` will be documented in this file
 - refactor interfaces from 'Support' namespace into 'Sfneal\ViewExport\Support\Interfaces' namespace.
 - add `download()` method to `ExcelExporter`
 - add use of `Storage` facade for uploading files to S3 instead of the S3 helper
+
+
+## 2.3.0 - 2021-03-24
+- cut $uploadPath param from `ExportService` methods & `Renderer` constructor in favor of using `Renderer::upload()` method
+- add methods to `Renderer` that allow for setting upload or storage paths prior to executing rendering (useful when interacting with the queue)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,11 @@ All notable changes to `view-export` will be documented in this file
 - optimize composer requirements by removing unused dependencies
 
 
+## 2.1.0 - 2021-03-24
+- cut $uploadPath param from `ExportService` methods & `Renderer` constructor in favor of using `Renderer::upload()` method
+- add methods to `Renderer` that allow for setting upload or storage paths prior to executing rendering (useful when interacting with the queue)
+
+
 ## 2.1.0 - 2021-03-22
 - refactor `Sfneal\ViewExport\Excel\Utils\ExcelView` to `Sfneal\ViewExport\Excel\Exports\ExcelViewExport` for easier expansion
 - fix `ExcelRenderer::setExcelView()` method to use string type hinting for $viewClass param

--- a/src/Excel/ExcelExportService.php
+++ b/src/Excel/ExcelExportService.php
@@ -13,23 +13,21 @@ class ExcelExportService extends ExportService
      * Provide a view to build the PDF from.
      *
      * @param View $view
-     * @param string|null $uploadPath
      * @return ExcelRenderer
      */
-    public static function fromView(View $view, string $uploadPath = null): ExcelRenderer
+    public static function fromView(View $view): ExcelRenderer
     {
-        return new ExcelRenderer($view, $uploadPath);
+        return new ExcelRenderer($view);
     }
 
     /**
      * Provide a view to build the PDF from.
      *
      * @param AbstractViewModel $viewModel
-     * @param string|null $uploadPath
      * @return ExcelRenderer
      */
-    public static function fromViewModel(AbstractViewModel $viewModel, string $uploadPath = null): ExcelRenderer
+    public static function fromViewModel(AbstractViewModel $viewModel): ExcelRenderer
     {
-        return new ExcelRenderer(view($viewModel->view, $viewModel->toArray()), $uploadPath);
+        return new ExcelRenderer(view($viewModel->view, $viewModel->toArray()));
     }
 }

--- a/src/Pdf/PdfExportService.php
+++ b/src/Pdf/PdfExportService.php
@@ -14,47 +14,43 @@ class PdfExportService extends ExportService implements FromHtml
      * Provide a view to build the PDF from.
      *
      * @param View $view
-     * @param string|null $uploadPath
      * @return PdfRenderer
      */
-    public static function fromView(View $view, string $uploadPath = null): PdfRenderer
+    public static function fromView(View $view): PdfRenderer
     {
-        return new PdfRenderer($view->render(), $uploadPath);
+        return new PdfRenderer($view->render());
     }
 
     /**
      * Provide a view to build the PDF from.
      *
      * @param AbstractViewModel $viewModel
-     * @param string|null $uploadPath
      * @return PdfRenderer
      */
-    public static function fromViewModel(AbstractViewModel $viewModel, string $uploadPath = null): PdfRenderer
+    public static function fromViewModel(AbstractViewModel $viewModel): PdfRenderer
     {
-        return new PdfRenderer($viewModel->renderNoCache(), $uploadPath);
+        return new PdfRenderer($viewModel->renderNoCache());
     }
 
     /**
      * Provide an HTML string to build the PDF from.
      *
      * @param string $html
-     * @param string|null $uploadPath
      * @return PdfRenderer
      */
-    public static function fromHtml(string $html, string $uploadPath = null): PdfRenderer
+    public static function fromHtml(string $html): PdfRenderer
     {
-        return new PdfRenderer($html, $uploadPath);
+        return new PdfRenderer($html);
     }
 
     /**
      * Provide an HTML path or URL to build the PDF from.
      *
      * @param string $path
-     * @param string|null $uploadPath
      * @return PdfRenderer
      */
-    public static function fromHtmlFile(string $path, string $uploadPath = null): PdfRenderer
+    public static function fromHtmlFile(string $path): PdfRenderer
     {
-        return new PdfRenderer(file_get_contents($path), $uploadPath);
+        return new PdfRenderer(file_get_contents($path));
     }
 }

--- a/src/Pdf/Utils/PdfRenderer.php
+++ b/src/Pdf/Utils/PdfRenderer.php
@@ -29,12 +29,11 @@ class PdfRenderer extends Renderer
      * PdfRenderer constructor.
      *
      * @param string $content
-     * @param string|null $uploadPath
      */
-    public function __construct(string $content, string $uploadPath = null)
+    public function __construct(string $content)
     {
         // Call Parent constructor
-        parent::__construct($content, $uploadPath);
+        parent::__construct($content);
 
         // Declare PDF options (use DefaultOptions) if none provided
         $this->options = new DefaultOptions();

--- a/src/Pdf/Utils/PdfRenderer.php
+++ b/src/Pdf/Utils/PdfRenderer.php
@@ -6,7 +6,6 @@ use Dompdf\Dompdf;
 use Dompdf\Exception;
 use Dompdf\Options;
 use Sfneal\Helpers\Strings\StringHelpers;
-use Sfneal\ViewExport\Support\Adapters\Exporter;
 use Sfneal\ViewExport\Support\Adapters\Renderer;
 
 class PdfRenderer extends Renderer
@@ -125,7 +124,7 @@ class PdfRenderer extends Renderer
     /**
      * Load renderable content to an Exporter instance and render the output.
      *
-     * @return Exporter|PdfExporter
+     * @return PdfExporter
      */
     public function handle(): PdfExporter
     {

--- a/src/Support/Adapters/ExportService.php
+++ b/src/Support/Adapters/ExportService.php
@@ -11,17 +11,15 @@ abstract class ExportService
      * Provide a view to build the export from.
      *
      * @param View $view
-     * @param string|null $uploadPath
      * @return Renderer
      */
-    abstract public static function fromView(View $view, string $uploadPath = null): Renderer;
+    abstract public static function fromView(View $view): Renderer;
 
     /**
      * Provide a view to build the export from.
      *
      * @param AbstractViewModel $viewModel
-     * @param string|null $uploadPath
      * @return Renderer
      */
-    abstract public static function fromViewModel(AbstractViewModel $viewModel, string $uploadPath = null): Renderer;
+    abstract public static function fromViewModel(AbstractViewModel $viewModel): Renderer;
 }

--- a/src/Support/Adapters/Exporter.php
+++ b/src/Support/Adapters/Exporter.php
@@ -3,8 +3,10 @@
 namespace Sfneal\ViewExport\Support\Adapters;
 
 use Illuminate\Support\Facades\Storage;
+use Sfneal\ViewExport\Support\Interfaces\Storable;
+use Sfneal\ViewExport\Support\Interfaces\Uploadable;
 
-abstract class Exporter
+abstract class Exporter implements Uploadable, Storable
 {
     /**
      * @var string|null local file path

--- a/src/Support/Adapters/Renderer.php
+++ b/src/Support/Adapters/Renderer.php
@@ -64,7 +64,7 @@ abstract class Renderer extends AbstractJob
      *
      *  - storing output in a property avoids potentially calling expensive 'output()' method multiple times
      *
-     * @return Exporter
+     * @return Exporter|mixed
      */
     public function handle(): Exporter
     {

--- a/src/Support/Adapters/Renderer.php
+++ b/src/Support/Adapters/Renderer.php
@@ -4,10 +4,8 @@ namespace Sfneal\ViewExport\Support\Adapters;
 
 use Illuminate\Support\Facades\Bus;
 use Sfneal\Queueables\AbstractJob;
-use Sfneal\ViewExport\Support\Interfaces\Storable;
-use Sfneal\ViewExport\Support\Interfaces\Uploadable;
 
-abstract class Renderer extends AbstractJob implements Uploadable, Storable
+abstract class Renderer extends AbstractJob
 {
     /**
      * @var mixed Renderable content
@@ -43,7 +41,7 @@ abstract class Renderer extends AbstractJob implements Uploadable, Storable
      * @param string $path
      * @return $this
      */
-    public function upload(string $path): self
+    public function setUploadPath(string $path): self
     {
         $this->uploadPath = $path;
 
@@ -56,7 +54,7 @@ abstract class Renderer extends AbstractJob implements Uploadable, Storable
      * @param string $storagePath
      * @return $this
      */
-    public function store(string $storagePath): Storable
+    public function setStorePath(string $storagePath): self
     {
         $this->storePath = $storagePath;
 

--- a/src/Support/Adapters/Renderer.php
+++ b/src/Support/Adapters/Renderer.php
@@ -4,8 +4,9 @@ namespace Sfneal\ViewExport\Support\Adapters;
 
 use Illuminate\Support\Facades\Bus;
 use Sfneal\Queueables\AbstractJob;
+use Sfneal\ViewExport\Support\Interfaces\Uploadable;
 
-abstract class Renderer extends AbstractJob
+abstract class Renderer extends AbstractJob implements Uploadable
 {
     /**
      * @var mixed Renderable content
@@ -23,15 +24,24 @@ abstract class Renderer extends AbstractJob
      * - $content can be a View or HTML file contents
      *
      * @param mixed $content
-     * @param string|null $uploadPath
      */
-    public function __construct($content, string $uploadPath = null)
+    public function __construct($content)
     {
         // Content of the PDF
         $this->content = $content;
+    }
 
-        // Upload PDF after rendering (defaults to false)
-        $this->uploadPath = $uploadPath;
+    /**
+     * Set a path to upload the Exportable to after it's been rendered.
+     *
+     * @param string $path
+     * @return $this
+     */
+    public function upload(string $path): self
+    {
+        $this->uploadPath = $path;
+
+        return $this;
     }
 
     /**
@@ -90,6 +100,8 @@ abstract class Renderer extends AbstractJob
         if ($this->uploadPath) {
             $exporter->upload($this->uploadPath);
         }
+
+        // todo: add storing?
 
         // Return a PdfExporter
         return $exporter;

--- a/src/Support/Interfaces/FromHtml.php
+++ b/src/Support/Interfaces/FromHtml.php
@@ -10,17 +10,15 @@ interface FromHtml
      * Provide an HTML string to build the PDF from.
      *
      * @param string $html
-     * @param string|null $uploadPath
      * @return Renderer
      */
-    public static function fromHtml(string $html, string $uploadPath = null): Renderer;
+    public static function fromHtml(string $html): Renderer;
 
     /**
      * Provide an HTML path or URL to build the PDF from.
      *
      * @param string $path
-     * @param string|null $uploadPath
      * @return Renderer
      */
-    public static function fromHtmlFile(string $path, string $uploadPath = null): Renderer;
+    public static function fromHtmlFile(string $path): Renderer;
 }

--- a/src/Support/Interfaces/Storable.php
+++ b/src/Support/Interfaces/Storable.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\ViewExport\Support\Interfaces;
-
 
 interface Storable
 {

--- a/src/Support/Interfaces/Storable.php
+++ b/src/Support/Interfaces/Storable.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Sfneal\ViewExport\Support\Interfaces;
+
+
+interface Storable
+{
+    /**
+     * Store a rendered export on the local file system.
+     *
+     * @param string $storagePath
+     * @return $this
+     */
+    public function store(string $storagePath): self;
+}

--- a/src/Support/Interfaces/Uploadable.php
+++ b/src/Support/Interfaces/Uploadable.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\ViewExport\Support\Interfaces;
-
 
 interface Uploadable
 {

--- a/src/Support/Interfaces/Uploadable.php
+++ b/src/Support/Interfaces/Uploadable.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Sfneal\ViewExport\Support\Interfaces;
+
+
+interface Uploadable
+{
+    /**
+     * Upload a rendered export to an AWS S3 file store.
+     *
+     * @param string $path
+     * @return $this
+     */
+    public function upload(string $path): self;
+}

--- a/tests/Pdf/PdfTestCase.php
+++ b/tests/Pdf/PdfTestCase.php
@@ -30,6 +30,21 @@ abstract class PdfTestCase extends TestCase
         $this->assertTrue(LaravelHelpers::isBinary($exporter->output()));
     }
 
+    /**
+     * Retrieve a storage path for a test PDF
+     *
+     * @return string
+     */
+    private function getStoragePath(): string
+    {
+        try {
+            $int = random_int(1000, 9999);
+        } catch (\Exception $e) {
+            $int = 1000;
+        }
+        return 'pdfs/output-'.$int.'.pdf';
+    }
+
     /** @test */
     public function initialize_exporter()
     {
@@ -44,7 +59,7 @@ abstract class PdfTestCase extends TestCase
     {
         $stored = $this->renderer
             ->handle()
-            ->store('pdfs/output-'.random_int(1000, 9999).'.pdf');
+            ->store($this->getStoragePath());
         $localPath = $stored->localPath();
 
         $this->assertIsString($localPath);
@@ -139,6 +154,25 @@ abstract class PdfTestCase extends TestCase
 
         // Assert that no jobs were pushed...
         Bus::assertNotDispatched(PdfRenderer::class);
+
+        // Dispatch the first job...
+        $this->renderer->handleJob();
+
+        // Assert a job was pushed...
+        Bus::assertDispatched(PdfRenderer::class);
+    }
+
+    /** @test */
+    public function validate_queueable_stored()
+    {
+        // Enable queue faking
+        Bus::fake();
+
+        // Assert that no jobs were pushed...
+        Bus::assertNotDispatched(PdfRenderer::class);
+
+        // Set a storage path
+        $this->renderer->store($this->getStoragePath());
 
         // Dispatch the first job...
         $this->renderer->handleJob();

--- a/tests/Pdf/PdfTestCase.php
+++ b/tests/Pdf/PdfTestCase.php
@@ -172,7 +172,7 @@ abstract class PdfTestCase extends TestCase
         Bus::assertNotDispatched(PdfRenderer::class);
 
         // Set a storage path
-        $this->renderer->store($this->getStoragePath());
+        $this->renderer->setStorePath($this->getStoragePath());
 
         // Dispatch the first job...
         $this->renderer->handleJob();

--- a/tests/Pdf/PdfTestCase.php
+++ b/tests/Pdf/PdfTestCase.php
@@ -31,7 +31,7 @@ abstract class PdfTestCase extends TestCase
     }
 
     /**
-     * Retrieve a storage path for a test PDF
+     * Retrieve a storage path for a test PDF.
      *
      * @return string
      */
@@ -42,6 +42,7 @@ abstract class PdfTestCase extends TestCase
         } catch (\Exception $e) {
             $int = 1000;
         }
+
         return 'pdfs/output-'.$int.'.pdf';
     }
 


### PR DESCRIPTION
- cut $uploadPath param from `ExportService` methods & `Renderer` constructor in favor of using `Renderer::upload()` method
- add methods to `Renderer` that allow for setting upload or storage paths prior to executing rendering (useful when interacting with the queue)