### PR TITLE
Font cache config key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,3 +214,8 @@ All notable changes to `view-export` will be documented in this file
 
 ## 2.5.0 - 2021-04-06
 - bump sfneal/view-models (^3.0) min version
+
+
+## 2.6.0 - 2021-04-13
+- add 'font_cache' key to view-export config for overriding the font cache directory
+- refactor config keys to be nested within a 'pdf' key (changes config access from `config('view-export.metadata')` to `config('view-export.pdf.metadata')`)

--- a/config/view-export.php
+++ b/config/view-export.php
@@ -25,6 +25,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Font Cache
+    |--------------------------------------------------------------------------
+    |
+    | dompdf's font cache directory.
+    |
+    | The location of the DOMPDF font cache directory
+    |
+    | This directory contains the cached font metrics for the fonts used by DOMPDF.
+    | This directory can be the same as $fontDir
+    |
+    | Note: This directory must exist and be writable by the webserver process.
+    |
+    | Default: leaving as 'null' will result in the 'chroot' being used as the
+    | font cache directory.
+    |
+    */
+    'font_cache' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | PHP enabled
     |--------------------------------------------------------------------------
     |

--- a/config/view-export.php
+++ b/config/view-export.php
@@ -1,148 +1,150 @@
 <?php
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Chroot
-    |--------------------------------------------------------------------------
-    |
-    | dompdf's "chroot".
-    |
-    | Prevents dompdf from accessing system files or other files on the webserver.
-    | All local files opened by dompdf must be in a subdirectory of this directory
-    | or array of directories.
-    | DO NOT set it to '/' since this could allow an attacker to use dompdf to
-    | read any files on the server.  This should be an absolute path.
-    |
-    | ==== IMPORTANT ====
-    | This setting may increase the risk of system exploit. Do not change
-    | this settings without understanding the consequences. Additional
-    | documentation is available on the dompdf wiki at:
-    | https://github.com/dompdf/dompdf/wiki
-    |
-    */
-    'chroot' => base_path('vendor/dompdf/dompdf'),
+    'pdf' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Chroot
+        |--------------------------------------------------------------------------
+        |
+        | dompdf's "chroot".
+        |
+        | Prevents dompdf from accessing system files or other files on the webserver.
+        | All local files opened by dompdf must be in a subdirectory of this directory
+        | or array of directories.
+        | DO NOT set it to '/' since this could allow an attacker to use dompdf to
+        | read any files on the server.  This should be an absolute path.
+        |
+        | ==== IMPORTANT ====
+        | This setting may increase the risk of system exploit. Do not change
+        | this settings without understanding the consequences. Additional
+        | documentation is available on the dompdf wiki at:
+        | https://github.com/dompdf/dompdf/wiki
+        |
+        */
+        'chroot' => base_path('vendor/dompdf/dompdf'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Font Cache
-    |--------------------------------------------------------------------------
-    |
-    | dompdf's font cache directory.
-    |
-    | The location of the DOMPDF font cache directory
-    |
-    | This directory contains the cached font metrics for the fonts used by DOMPDF.
-    | This directory can be the same as $fontDir
-    |
-    | Note: This directory must exist and be writable by the webserver process.
-    |
-    | Default: leaving as 'null' will result in the 'chroot' being used as the
-    | font cache directory.
-    |
-    */
-    'font_cache' => null,
+        /*
+        |--------------------------------------------------------------------------
+        | Font Cache
+        |--------------------------------------------------------------------------
+        |
+        | dompdf's font cache directory.
+        |
+        | The location of the DOMPDF font cache directory
+        |
+        | This directory contains the cached font metrics for the fonts used by DOMPDF.
+        | This directory can be the same as $fontDir
+        |
+        | Note: This directory must exist and be writable by the webserver process.
+        |
+        | Default: leaving as 'null' will result in the 'chroot' being used as the
+        | font cache directory.
+        |
+        */
+        'font_cache' => null,
 
-    /*
-    |--------------------------------------------------------------------------
-    | PHP enabled
-    |--------------------------------------------------------------------------
-    |
-    | Enable embedded PHP.
-    |
-    | If this setting is set to true then DOMPDF will automatically evaluate
-    | embedded PHP contained within <script type="text/php"> ... </script> tags.
-    |
-    | ==== IMPORTANT ====
-    | Enabling this for documents you do not trust (e.g. arbitrary remote html
-    | pages) is a security risk. Embedded scripts are run with the same level of
-    | system access available to dompdf. Set this option to false (recommended)
-    | if you wish to process untrusted documents.
-    |
-    | This setting may increase the risk of system exploit. Do not change
-    | this settings without understanding the consequences. Additional
-    | documentation is available on the dompdf wiki at:
-    | https://github.com/dompdf/dompdf/wiki
-    |
-    */
-    'php_enabled' => true,
+        /*
+        |--------------------------------------------------------------------------
+        | PHP enabled
+        |--------------------------------------------------------------------------
+        |
+        | Enable embedded PHP.
+        |
+        | If this setting is set to true then DOMPDF will automatically evaluate
+        | embedded PHP contained within <script type="text/php"> ... </script> tags.
+        |
+        | ==== IMPORTANT ====
+        | Enabling this for documents you do not trust (e.g. arbitrary remote html
+        | pages) is a security risk. Embedded scripts are run with the same level of
+        | system access available to dompdf. Set this option to false (recommended)
+        | if you wish to process untrusted documents.
+        |
+        | This setting may increase the risk of system exploit. Do not change
+        | this settings without understanding the consequences. Additional
+        | documentation is available on the dompdf wiki at:
+        | https://github.com/dompdf/dompdf/wiki
+        |
+        */
+        'php_enabled' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Javascript enabled
-    |--------------------------------------------------------------------------
-    |
-    | Enable inline Javascript.
-    |
-    | If this setting is set to true then DOMPDF will automatically insert
-    | JavaScript code contained within <script type="text/javascript"> ... </script> tags.
-    |
-    */
-    'javascript_enabled' => true,
+        /*
+        |--------------------------------------------------------------------------
+        | Javascript enabled
+        |--------------------------------------------------------------------------
+        |
+        | Enable inline Javascript.
+        |
+        | If this setting is set to true then DOMPDF will automatically insert
+        | JavaScript code contained within <script type="text/javascript"> ... </script> tags.
+        |
+        */
+        'javascript_enabled' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | HTML 5 parsable enabled
-    |--------------------------------------------------------------------------
-    |
-    | Use the more-than-experimental HTML5 Lib parser.
-    |
-    */
-    'html5_parsable' => true,
+        /*
+        |--------------------------------------------------------------------------
+        | HTML 5 parsable enabled
+        |--------------------------------------------------------------------------
+        |
+        | Use the more-than-experimental HTML5 Lib parser.
+        |
+        */
+        'html5_parsable' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Remote enabled
-    |--------------------------------------------------------------------------
-    |
-    | Enable remote file access.
-    |
-    | If this setting is set to true, DOMPDF will access remote sites for
-    | images and CSS files as required.
-    |
-    | ==== IMPORTANT ====
-    | This can be a security risk, in particular in combination with isPhpEnabled and
-    | allowing remote html code to be passed to $dompdf = new DOMPDF(); $dompdf->load_html(...);
-    | This allows anonymous users to download legally doubtful internet content which on
-    | tracing back appears to being downloaded by your server, or allows malicious php code
-    | in remote html pages to be executed by your server with your account privileges.
-    |
-    | This setting may increase the risk of system exploit. Do not change
-    | this settings without understanding the consequences. Additional
-    | documentation is available on the dompdf wiki at:
-    | https://github.com/dompdf/dompdf/wiki
-    |
-    */
-    'remote_enabled' => true,
+        /*
+        |--------------------------------------------------------------------------
+        | Remote enabled
+        |--------------------------------------------------------------------------
+        |
+        | Enable remote file access.
+        |
+        | If this setting is set to true, DOMPDF will access remote sites for
+        | images and CSS files as required.
+        |
+        | ==== IMPORTANT ====
+        | This can be a security risk, in particular in combination with isPhpEnabled and
+        | allowing remote html code to be passed to $dompdf = new DOMPDF(); $dompdf->load_html(...);
+        | This allows anonymous users to download legally doubtful internet content which on
+        | tracing back appears to being downloaded by your server, or allows malicious php code
+        | in remote html pages to be executed by your server with your account privileges.
+        |
+        | This setting may increase the risk of system exploit. Do not change
+        | this settings without understanding the consequences. Additional
+        | documentation is available on the dompdf wiki at:
+        | https://github.com/dompdf/dompdf/wiki
+        |
+        */
+        'remote_enabled' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Log Output
-    |--------------------------------------------------------------------------
-    |
-    | The file that Dompdf logs should be written to.
-    |
-    */
-    'log_output' => storage_path('logs/dompdf.htm'),
+        /*
+        |--------------------------------------------------------------------------
+        | Log Output
+        |--------------------------------------------------------------------------
+        |
+        | The file that Dompdf logs should be written to.
+        |
+        */
+        'log_output' => storage_path('logs/dompdf.htm'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | PDF Metadata default
-    |--------------------------------------------------------------------------
-    |
-    | PDF metadata that should be used by default.
-    |
-    */
-    'metadata' => [
-        //        'Title' => '',
-        //        'Author' => '',
-        //        'Subject' => '',
-        //        'Keywords' => '',
-        //        'Creator' => '',
-        //        'Producer' => '',
-        //        'CreationDate' => '',
-        //        'ModDate' => '',
-        //        'Trapped' => '',
+        /*
+        |--------------------------------------------------------------------------
+        | PDF Metadata default
+        |--------------------------------------------------------------------------
+        |
+        | PDF metadata that should be used by default.
+        |
+        */
+        'metadata' => [
+            //        'Title' => '',
+            //        'Author' => '',
+            //        'Subject' => '',
+            //        'Keywords' => '',
+            //        'Creator' => '',
+            //        'Producer' => '',
+            //        'CreationDate' => '',
+            //        'ModDate' => '',
+            //        'Trapped' => '',
+        ],
     ],
 
 ];

--- a/src/Pdf/Utils/DefaultOptions.php
+++ b/src/Pdf/Utils/DefaultOptions.php
@@ -26,21 +26,21 @@ class DefaultOptions extends Options
     private function setDefaults(): self
     {
         // Set file permissions
-        $this->setChroot(config('view-export.chroot'));
+        $this->setChroot(config('view-export.pdf.chroot'));
 
         // Set font cache directory (if overwritten in config)
-        if (config('view-export.font_cache')) {
-            $this->setFontCache(config('view-export.font_cache'));
+        if (config('view-export.pdf.font_cache')) {
+            $this->setFontCache(config('view-export.pdf.font_cache'));
         }
 
         // Set parsing options
-        $this->setIsPhpEnabled(config('view-export.php_enabled'));
-        $this->setIsJavascriptEnabled(config('view-export.javascript_enabled'));
-        $this->setIsHtml5ParserEnabled(config('view-export.html5_parsable'));
-        $this->setIsRemoteEnabled(config('view-export.remote_enabled'));
+        $this->setIsPhpEnabled(config('view-export.pdf.php_enabled'));
+        $this->setIsJavascriptEnabled(config('view-export.pdf.javascript_enabled'));
+        $this->setIsHtml5ParserEnabled(config('view-export.pdf.html5_parsable'));
+        $this->setIsRemoteEnabled(config('view-export.pdf.remote_enabled'));
 
         // Set logging directory
-        $this->setLogOutputFile(config('view-export.log_output'));
+        $this->setLogOutputFile(config('view-export.pdf.log_output'));
 
         return $this;
     }

--- a/src/Pdf/Utils/DefaultOptions.php
+++ b/src/Pdf/Utils/DefaultOptions.php
@@ -25,13 +25,19 @@ class DefaultOptions extends Options
      */
     private function setDefaults(): self
     {
+        // Set file permissions
+        $this->setChroot(config('view-export.chroot'));
+
+        // Set font cache directory (if overwritten in config)
+        if (config('view-export.font_cache')) {
+            $this->setFontCache(config('view-export.font_cache'));
+        }
+
+        // Set parsing options
         $this->setIsPhpEnabled(config('view-export.php_enabled'));
         $this->setIsJavascriptEnabled(config('view-export.javascript_enabled'));
         $this->setIsHtml5ParserEnabled(config('view-export.html5_parsable'));
         $this->setIsRemoteEnabled(config('view-export.remote_enabled'));
-
-        // Set file permissions
-        $this->setChroot(config('view-export.chroot'));
 
         // Set logging directory
         $this->setLogOutputFile(config('view-export.log_output'));

--- a/src/Pdf/Utils/Metadata.php
+++ b/src/Pdf/Utils/Metadata.php
@@ -38,7 +38,7 @@ class Metadata
     public function __construct(array $metadata = null)
     {
         if (! empty($metadata)) {
-            $this->set($metadata ?? config('view-export.metadata'));
+            $this->set($metadata ?? config('view-export.pdf.metadata'));
         }
     }
 

--- a/tests/LaravelConfigTest.php
+++ b/tests/LaravelConfigTest.php
@@ -8,13 +8,14 @@ class LaravelConfigTest extends TestCase
     public function config_is_accessible()
     {
         // Confirm the view-export config array exists
+        $this->assertIsArray(config('view-export.pdf'));
         $this->assertIsArray(config('view-export'));
     }
 
     /** @test */
     public function chroot()
     {
-        $output = config('view-export.chroot');
+        $output = config('view-export.pdf.chroot');
         $expected = base_path('vendor/dompdf/dompdf');
 
         $this->assertIsString($output);
@@ -25,7 +26,7 @@ class LaravelConfigTest extends TestCase
     /** @test */
     public function php_enabled()
     {
-        $output = config('view-export.php_enabled');
+        $output = config('view-export.pdf.php_enabled');
         $expected = true;
 
         $this->assertIsBool($output);
@@ -35,7 +36,7 @@ class LaravelConfigTest extends TestCase
     /** @test */
     public function javascript_enabled()
     {
-        $output = config('view-export.javascript_enabled');
+        $output = config('view-export.pdf.javascript_enabled');
         $expected = true;
 
         $this->assertIsBool($output);
@@ -45,7 +46,7 @@ class LaravelConfigTest extends TestCase
     /** @test */
     public function html5_parsable()
     {
-        $output = config('view-export.html5_parsable');
+        $output = config('view-export.pdf.html5_parsable');
         $expected = true;
 
         $this->assertIsBool($output);
@@ -55,7 +56,7 @@ class LaravelConfigTest extends TestCase
     /** @test */
     public function remote_enabled()
     {
-        $output = config('view-export.remote_enabled');
+        $output = config('view-export.pdf.remote_enabled');
         $expected = true;
 
         $this->assertIsBool($output);
@@ -72,9 +73,9 @@ class LaravelConfigTest extends TestCase
             'Creator' => 'sfneal/view-export',
             'Producer' => 'dompdf/dompdf',
         ];
-        $this->app['config']->set('view-export.metadata', $metadata);
+        $this->app['config']->set('view-export.pdf.metadata', $metadata);
 
-        $output = config('view-export.metadata');
+        $output = config('view-export.pdf.metadata');
         $expected = $metadata;
 
         $this->assertIsArray($output);

--- a/tests/Pdf/PdfExportFromUrlTest.php
+++ b/tests/Pdf/PdfExportFromUrlTest.php
@@ -15,6 +15,6 @@ class PdfExportFromUrlTest extends PdfTestCase
     {
         parent::setUp();
 
-        $this->renderer = PdfExportService::fromHtmlFile('http://example.com/');
+        $this->renderer = PdfExportService::fromHtmlFile('https://example.com/');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,6 +32,7 @@ class TestCase extends OrchestraTestCase
     {
         $app->setBasePath(__DIR__.'/../');
         $app['config']->set('view-export.chroot', $app->basePath().'/vendor/dompdf/dompdf');
+        $app['config']->set('view-export.font_cache', $app->storagePath().'/fonts');
         chmod(config('view-export.chroot'), 0755);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,9 +31,9 @@ class TestCase extends OrchestraTestCase
     protected function getEnvironmentSetUp($app)
     {
         $app->setBasePath(__DIR__.'/../');
-        $app['config']->set('view-export.chroot', $app->basePath().'/vendor/dompdf/dompdf');
-        $app['config']->set('view-export.font_cache', $app->storagePath().'/fonts');
-        chmod(config('view-export.chroot'), 0755);
+        $app['config']->set('view-export.pdf.chroot', $app->basePath().'/vendor/dompdf/dompdf');
+        $app['config']->set('view-export.pdf.font_cache', $app->storagePath().'/fonts');
+        chmod(config('view-export.pdf.chroot'), 0755);
     }
 
     /**


### PR DESCRIPTION
- add 'font_cache' key to view-export config for overriding the font cache directory
- refactor config keys to be nested within a 'pdf' key (changes config access from `config('view-export.metadata')` to `config('view-export.pdf.metadata')`)