### PR TITLE
PDF export content loader types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,3 +219,9 @@ All notable changes to `view-export` will be documented in this file
 ## 2.6.0 - 2021-04-13
 - add 'font_cache' key to view-export config for overriding the font cache directory
 - refactor config keys to be nested within a 'pdf' key (changes config access from `config('view-export.metadata')` to `config('view-export.pdf.metadata')`)
+
+
+## 2.7.0 - 2021-05-21
+- add ability to load content via a static HTML file or directly into the PDF
+- add contentLoader methods to `DefaultOptions` for getting & setting pdf content loader types
+- add 'content_loader' config key for setting a default loader

--- a/config/view-export.php
+++ b/config/view-export.php
@@ -145,6 +145,20 @@ return [
             //        'ModDate' => '',
             //        'Trapped' => '',
         ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | PDF Content Loader convention
+        |--------------------------------------------------------------------------
+        |
+        | Determine if PDF content should be loaded using the 'disk' to export a
+        | static HTML file prior to loading into the PDF.  Set the value to
+        | 'memory' if you would like load HTML stored in memory directly to the PDF.
+        |
+        | Values: 'memory' or 'disk'
+        |
+        */
+        'content_loader' => 'disk',
     ],
 
 ];

--- a/src/Pdf/Utils/DefaultOptions.php
+++ b/src/Pdf/Utils/DefaultOptions.php
@@ -53,7 +53,7 @@ class DefaultOptions extends Options
         $this->setLogOutputFile(config('view-export.pdf.log_output'));
 
         // Set content loader
-        $this->setContentLoader(config('view-export.pdf.content_loader'));
+        $this->setContentLoader(config('view-export.pdf.content_loader', 'disk'));
     }
 
     /**

--- a/src/Pdf/Utils/DefaultOptions.php
+++ b/src/Pdf/Utils/DefaultOptions.php
@@ -7,6 +7,16 @@ use Dompdf\Options;
 class DefaultOptions extends Options
 {
     /**
+     * Set the content loader convention
+     *
+     *  - If this setting is set to 'disk' PDF content will be exported to a static HTML.
+     *  - If this setting is set to 'memory' PDF content will be loaded directly to the PDF.
+     *
+     * @var string
+     */
+    private $contentLoader;
+
+    /**
      * DefaultOptions constructor.
      *
      * @param array|null $attributes
@@ -42,6 +52,9 @@ class DefaultOptions extends Options
         // Set logging directory
         $this->setLogOutputFile(config('view-export.pdf.log_output'));
 
+        // Set content loader
+        $this->setContentLoader(config('view-export.pdf.content_loader'));
+
     }
 
     /**
@@ -66,5 +79,68 @@ class DefaultOptions extends Options
         $this->setDefaultPaperOrientation('portrait');
 
         return $this;
+    }
+
+    /**
+     * Set the content loader type as 'disk'.
+     *
+     * @return $this
+     */
+    public function setContentLoaderDisk(): self
+    {
+        return $this->setContentLoader('disk');
+    }
+
+    /**
+     * Set the content loader type as 'memory'.
+     *
+     * @return $this
+     */
+    public function setContentLoaderMemory(): self
+    {
+        return $this->setContentLoader('memory');
+    }
+
+    /**
+     * Set the content loader type.
+     *
+     * @param string $loader
+     * @return $this
+     */
+    private function setContentLoader(string $loader): self
+    {
+        $this->contentLoader = $loader;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the content loader type is 'disk'.
+     *
+     * @return bool
+     */
+    public function isContentLoaderDisk(): bool
+    {
+        return $this->getContentLoader() == 'disk';
+    }
+
+    /**
+     * Determine if the content loader type is 'memory'.
+     *
+     * @return bool
+     */
+    public function isContentLoaderMemory(): bool
+    {
+        return $this->getContentLoader() == 'memory';
+    }
+
+    /**
+     * Retrieve the content loader type.
+     *
+     * @return string
+     */
+    public function getContentLoader(): string
+    {
+        return $this->contentLoader;
     }
 }

--- a/src/Pdf/Utils/DefaultOptions.php
+++ b/src/Pdf/Utils/DefaultOptions.php
@@ -21,9 +21,9 @@ class DefaultOptions extends Options
     /**
      * Set the default Dompdf Options.
      *
-     * @return $this
+     * @return void
      */
-    private function setDefaults(): self
+    private function setDefaults(): void
     {
         // Set file permissions
         $this->setChroot(config('view-export.pdf.chroot'));
@@ -42,7 +42,6 @@ class DefaultOptions extends Options
         // Set logging directory
         $this->setLogOutputFile(config('view-export.pdf.log_output'));
 
-        return $this;
     }
 
     /**

--- a/src/Pdf/Utils/DefaultOptions.php
+++ b/src/Pdf/Utils/DefaultOptions.php
@@ -7,7 +7,7 @@ use Dompdf\Options;
 class DefaultOptions extends Options
 {
     /**
-     * Set the content loader convention
+     * Set the content loader convention.
      *
      *  - If this setting is set to 'disk' PDF content will be exported to a static HTML.
      *  - If this setting is set to 'memory' PDF content will be loaded directly to the PDF.
@@ -54,7 +54,6 @@ class DefaultOptions extends Options
 
         // Set content loader
         $this->setContentLoader(config('view-export.pdf.content_loader'));
-
     }
 
     /**

--- a/src/Pdf/Utils/PdfRenderer.php
+++ b/src/Pdf/Utils/PdfRenderer.php
@@ -80,18 +80,17 @@ class PdfRenderer extends Renderer
     /**
      * Add Metadata to the PDF.
      *
-     * @return bool
+     * @return void
      */
-    private function applyMetadata(): bool
+    private function applyMetadata(): void
     {
         // Add Metadata if the array isn't empty
-        if ($hasMetadata = ! empty($this->metadata->get())) {
+        if (! empty($this->metadata->get())) {
             foreach ($this->metadata->get() as $key => $value) {
                 $this->pdf->add_info($key, $value);
             }
         }
 
-        return $hasMetadata;
     }
 
     /**

--- a/src/Pdf/Utils/PdfRenderer.php
+++ b/src/Pdf/Utils/PdfRenderer.php
@@ -90,7 +90,6 @@ class PdfRenderer extends Renderer
                 $this->pdf->add_info($key, $value);
             }
         }
-
     }
 
     /**
@@ -123,7 +122,6 @@ class PdfRenderer extends Renderer
                 unlink($localHTML);
             }
         }
-
     }
 
     /**

--- a/src/Pdf/Utils/PdfRenderer.php
+++ b/src/Pdf/Utils/PdfRenderer.php
@@ -100,23 +100,30 @@ class PdfRenderer extends Renderer
      */
     private function loadContent(): void
     {
-        // todo: implement this if it improves performance
-//        $this->pdf->loadHtml($this->content);
-
-        // Create local HTML file path
-        $localHTML = StringHelpers::joinPaths($this->options->getRootDir(), uniqid().'.html');
-
-        // Store View (or HTML) as HTML file within Dompdf root
-        touch($localHTML);
-        file_put_contents($localHTML, $this->content);
-
-        // Load HTML
-        $this->pdf->loadHtmlFile($localHTML);
-
-        // Remove temp HTML file if app is NOT in 'debug' mode
-        if (! config('app.debug')) {
-            unlink($localHTML);
+        // Use 'memory' content loader
+        if ($this->options->isContentLoaderMemory()) {
+            $this->pdf->loadHtml($this->content);
         }
+
+        // Use 'disk' content loader
+        elseif ($this->options->isContentLoaderDisk()) {
+
+            // Create local HTML file path
+            $localHTML = StringHelpers::joinPaths($this->options->getRootDir(), uniqid().'.html');
+
+            // Store View (or HTML) as HTML file within Dompdf root
+            touch($localHTML);
+            file_put_contents($localHTML, $this->content);
+
+            // Load HTML
+            $this->pdf->loadHtmlFile($localHTML);
+
+            // Remove temp HTML file if app is NOT in 'debug' mode
+            if (! config('app.debug')) {
+                unlink($localHTML);
+            }
+        }
+
     }
 
     /**

--- a/tests/Pdf/PdfTestCase.php
+++ b/tests/Pdf/PdfTestCase.php
@@ -181,4 +181,36 @@ abstract class PdfTestCase extends TestCase
         // Assert a job was pushed...
         Bus::assertDispatched(PdfRenderer::class);
     }
+
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function export_using_disk_content_loader()
+    {
+        // Set 'disk' content loader
+        $this->renderer->options->setContentLoaderDisk();
+
+        // Render the PDF
+        $exporter = $this->renderer->handle();
+
+        // Execute assertions
+        $this->executeAssertions($exporter);
+    }
+
+    /**
+     * @test
+     * @throws Exception
+     */
+    public function export_using_memory_content_loader()
+    {
+        // Set 'disk' content loader
+        $this->renderer->options->setContentLoaderMemory();
+
+        // Render the PDF
+        $exporter = $this->renderer->handle();
+
+        // Execute assertions
+        $this->executeAssertions($exporter);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,8 @@ use Sfneal\ViewExport\Providers\ViewExportServiceProvider;
 
 class TestCase extends OrchestraTestCase
 {
+    // todo: refactor test suite into Unit & Feature
+
     /**
      * Get package providers.
      *


### PR DESCRIPTION
- add ability to load content via a static HTML file or directly into the PDF
- add contentLoader methods to `DefaultOptions` for getting & setting pdf content loader types
- add 'content_loader' config key for setting a default loader