### PR TITLE
`PdfStatus` interface for Models with PDF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,3 +230,7 @@ All notable changes to `view-export` will be documented in this file
 ## 2.8.0 - 2021-05-27
 - fix 'view-config.pdf.metadata' config key to use empty values by default instead of commenting them out
 - add private `getConfigMetadata()` method for retrieving the config metadata with empty values removed
+
+
+## 2.9.0 - 2021-06-10
+- add `PdfStatus` interface for implementing `pdfExists()` & `pdfProcessing()` methods on Models with PDF files

--- a/src/Pdf/Interfaces/PdfStatus.php
+++ b/src/Pdf/Interfaces/PdfStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace Sfneal\ViewExport\Pdf\Interfaces;
+
+
+interface PdfStatus
+{
+    // todo: add tests
+
+    /**
+     * Determine if the Model's PDF exists.
+     *
+     * @return bool
+     */
+    public function pdfExists(): bool;
+
+    /**
+     * Determine if the Model's PDF is processing.
+     *
+     * @return bool
+     */
+    public function pdfProcessing(): bool;
+}

--- a/src/Pdf/Interfaces/PdfStatus.php
+++ b/src/Pdf/Interfaces/PdfStatus.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\ViewExport\Pdf\Interfaces;
-
 
 interface PdfStatus
 {


### PR DESCRIPTION
- add `PdfStatus` interface for implementing `pdfExists()` & `pdfProcessing()` methods on Models with PDF files